### PR TITLE
code fmt; Arduino CI; remove TRACE; moved PROGMEM

### DIFF
--- a/.github/workflows/build_arduino.yml
+++ b/.github/workflows/build_arduino.yml
@@ -1,0 +1,92 @@
+name: Arduino CLI build
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/build_arduino.yml"
+      - "examples/**"
+
+  push:
+    paths:
+      - ".github/workflows/build_arduino.yml"
+      - "examples/**"
+
+jobs:
+  check_formatting:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check code formatting
+        uses: per1234/artistic-style-action@main
+        with:
+          options-file-path: ./examples/examples_formatter.conf
+          name-patterns: |
+            - '*.ino'
+            - '*.cpp'
+            - '*.hpp'
+            - '*.h'
+          target-paths: |
+            - examples
+  build:
+    needs: check_formatting
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        fqbn:
+          - "arduino:avr:yun"
+          - "arduino:avr:uno"
+          - "arduino:avr:diecimila"
+          - "arduino:avr:nano"
+          - "arduino:avr:mega"
+          - "arduino:avr:megaADK"
+          - "arduino:avr:leonardo"
+          - "arduino:avr:micro"
+          - "arduino:avr:esplora"
+          - "arduino:avr:mini"
+          - "arduino:avr:ethernet"
+          - "arduino:avr:fio"
+          - "arduino:avr:bt"
+          # - "arduino:avr:LilyPad"  # board not found
+          - "arduino:avr:LilyPadUSB"
+          - "arduino:avr:pro"
+          - "arduino:avr:atmegang"
+          - "arduino:avr:robotControl"
+          - "arduino:avr:robotMotor"
+          # - "arduino:avr:gemma"  # does not support SPI
+          - "arduino:avr:circuitplay32u4cat"
+          - "arduino:avr:yunmini"
+          - "arduino:avr:chiwawa"
+          - "arduino:avr:one"
+          - "arduino:avr:unowifi"
+          - "arduino:mbed:nano33ble"
+          # - "arduino:samd:mkr1000"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrzero"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrwifi1010"  # InterruptConfigure.ino uses pin 2
+          - "arduino:samd:nano_33_iot"
+          # - "arduino:samd:mkrfox1200"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrwan1300"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrwan1310"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrgsm1400"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrnb1500"  # InterruptConfigure.ino uses pin 2
+          # - "arduino:samd:mkrvidor4000"  # InterruptConfigure.ino uses pin 2
+          - "arduino:samd:adafruit_circuitplayground_m0"
+          - "arduino:samd:mzero_pro_bl"
+          - "arduino:samd:mzero_bl"
+          - "arduino:samd:tian"
+          - "arduino:megaavr:uno2018"
+          # - "arduino:megaavr:nano4809"  # board not found
+          - "arduino:sam:arduino_due_x_dbg"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Compile examples
+        uses: arduino/compile-sketches@main
+        with:
+          fqbn: ${{ matrix.fqbn }}

--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,6 @@ dkms.conf
 .project
 .settings
 
-
 # local-specific working dir
 .vscode/
 docs/html/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,9 @@
+These are the current requirements for getting your code included in RF24:
+
+* Try your best to follow the rest of the code, if you're unsure then the NASA C style can help as it's closest to the current style: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950022400.pdf
+
+* Definetly follow [PEP-8](https://www.python.org/dev/peps/pep-0008/) if it's Python code.
+
+* Follow the [Arduino IDE formatting style](https://www.arduino.cc/en/Reference/StyleGuide) for Arduino examples
+
+* Add [doxygen-compatible documentation](https://www.doxygen.nl/manual/docblocks.html) to any new functions you add, or update existing documentation if you change behaviour

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,6 @@ These are the current requirements for getting your code included in RF24:
 
 * Try your best to follow the rest of the code, if you're unsure then the NASA C style can help as it's closest to the current style: https://ntrs.nasa.gov/archive/nasa/casi.ntrs.nasa.gov/19950022400.pdf
 
-* Definetly follow [PEP-8](https://www.python.org/dev/peps/pep-0008/) if it's Python code.
-
 * Follow the [Arduino IDE formatting style](https://www.arduino.cc/en/Reference/StyleGuide) for Arduino examples
 
 * Add [doxygen-compatible documentation](https://www.doxygen.nl/manual/docblocks.html) to any new functions you add, or update existing documentation if you change behaviour

--- a/examples/AllLogLevelsLogger/AllLogLevelsLogger.ino
+++ b/examples/AllLogLevelsLogger/AllLogLevelsLogger.ino
@@ -28,26 +28,26 @@ const char vendorID[] PROGMEM = "RF24LogExample";
 
 void setup()
 {
-   // configure serial port baudrate
-   Serial.begin(115200);
+  // configure serial port baudrate
+  Serial.begin(115200);
 
-   // set maximal log level to ALL
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
-   // set serial port appender
-   rf24Logger.setHandler(&rf24SerialLogHandler);
+  // set maximal log level to ALL
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
+  // set serial port appender
+  rf24Logger.setHandler(&rf24SerialLogHandler);
 
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/AllLogLevelsLogger"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/AllLogLevelsLogger"));
 }
 
 void loop()
 {
-   for(uint16_t logLevel = 0 ; logLevel <= 255 ; logLevel ++)
-   {
-      rf24Logger.log((uint8_t)logLevel, (const __FlashStringHelper*)vendorID, F("This is a log message with level %d"), logLevel);
-   }
+  for (uint16_t logLevel = 0 ; logLevel <= 255 ; logLevel ++)
+  {
+    rf24Logger.log((uint8_t)logLevel, (const __FlashStringHelper*)vendorID, F("This is a log message with level %d"), logLevel);
+  }
 
-   Serial.println("");
-   delay(5000);
+  Serial.println("");
+  delay(5000);
 }
 
 

--- a/examples/AllLogLevelsLogger/AllLogLevelsLogger.ino
+++ b/examples/AllLogLevelsLogger/AllLogLevelsLogger.ino
@@ -24,7 +24,7 @@
 RF24StreamLogHandler rf24SerialLogHandler(&Serial);
 
 // Define global vendor id (it is stored in flash memory)
-const char vendorID[] PROGMEM = "RF24LogExample";
+const char PROGMEM vendorID[] = "RF24LogExample";
 
 void setup()
 {
@@ -49,5 +49,3 @@ void loop()
   Serial.println("");
   delay(5000);
 }
-
-

--- a/examples/BasicSerialLogger/BasicSerialLogger.ino
+++ b/examples/BasicSerialLogger/BasicSerialLogger.ino
@@ -24,14 +24,12 @@
 RF24StreamLogHandler rf24SerialLogHandler(&Serial);
 
 // Define global vendor id (it is stored in flash memory)
-const char vendorID[] PROGMEM = "RF24LogExample";
+const char PROGMEM vendorID[] = "RF24LogExample";
 
 
 // Define some test messages stored in EEPROM
-const char globalProgmemText[] PROGMEM
-  = "global PROGMEM message";
-const char globalProgmemMessageWithRamString[] PROGMEM
-  = "PROGMEM message with %s";
+const char PROGMEM globalProgmemText[] = "global PROGMEM message";
+const char PROGMEM globalProgmemMessageWithRamString[] = "PROGMEM message with %s";
 
 void setup()
 {

--- a/examples/BasicSerialLogger/BasicSerialLogger.ino
+++ b/examples/BasicSerialLogger/BasicSerialLogger.ino
@@ -29,21 +29,21 @@ const char vendorID[] PROGMEM = "RF24LogExample";
 
 // Define some test messages stored in EEPROM
 const char globalProgmemText[] PROGMEM
-= "global PROGMEM message";
+  = "global PROGMEM message";
 const char globalProgmemMessageWithRamString[] PROGMEM
-= "PROGMEM message with %s";
+  = "PROGMEM message with %s";
 
 void setup()
 {
-   // configure serial port baudrate
-   Serial.begin(115200);
+  // configure serial port baudrate
+  Serial.begin(115200);
 
-   // set maximal log level to ALL
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
-   // set serial port appender
-   rf24Logger.setHandler(&rf24SerialLogHandler);
+  // set maximal log level to ALL
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
+  // set serial port appender
+  rf24Logger.setHandler(&rf24SerialLogHandler);
 
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/BasicSerialLogger"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/BasicSerialLogger"));
 }
 
 void logSimpleRamMessage();
@@ -60,191 +60,167 @@ void logCustomLogLevels();
 
 void loop()
 {
-   logSimpleRamMessage();
-   logSimpleGlobalProgmemMessage();
-   logSimpleFMacroMessage();
-   logRamMessageWithRamStringArgument();
-   logRamMessageWithProgmemStringArgument();
-   logRamMessageWithFMacroStringArgument();
-   logProgmemMessageWithRamStringArgument();
-   logMessageWithAdditionalTagAtTheBeginning();
-   logMessageWithUnknownFormat();
-   logFloatNumber();
-   logCustomLogLevels();
+  logSimpleRamMessage();
+  logSimpleGlobalProgmemMessage();
+  logSimpleFMacroMessage();
+  logRamMessageWithRamStringArgument();
+  logRamMessageWithProgmemStringArgument();
+  logRamMessageWithFMacroStringArgument();
+  logProgmemMessageWithRamStringArgument();
+  logMessageWithAdditionalTagAtTheBeginning();
+  logMessageWithUnknownFormat();
+  logFloatNumber();
+  logCustomLogLevels();
 
-   Serial.println();
-   Serial.println("--------------------------------------------------");
-   Serial.println();
+  Serial.println();
+  Serial.println("--------------------------------------------------");
+  Serial.println();
 
-   delay(5000);
+  delay(5000);
 }
 
 void logSimpleRamMessage()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "Error message defined in RAM");
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         "Warning message defined in RAM");
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         "Info message defined in RAM");
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "Debug message defined in RAM");
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "Trace message defined in RAM");
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "Error message defined in RAM");
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  "Warning message defined in RAM");
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  "Info message defined in RAM");
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "Debug message defined in RAM");
 
-   Serial.println();
+  Serial.println();
 }
 
 void logSimpleGlobalProgmemMessage()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   (const __FlashStringHelper*) globalProgmemText);
 
-   Serial.println();
+  Serial.println();
 }
 
 void logSimpleFMacroMessage()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         F("text from F macro"));
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         F("text from F macro"));
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         F("text from F macro"));
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         F("text from F macro"));
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         F("text from F macro"));
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   F("text from F macro"));
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  F("text from F macro"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  F("text from F macro"));
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   F("text from F macro"));
 
-   Serial.println();
+  Serial.println();
 }
 
 void logRamMessageWithRamStringArgument()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "RAM message with %s", "RAM string 1");
-   rf24Logger.warn((const __FlashStringHelper*) vendorID, "RAM message with %s",
-         "RAM string 2");
-   rf24Logger.info((const __FlashStringHelper*) vendorID, "RAM message with %s",
-         "RAM string 3");
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "RAM message with %s", "RAM string 4");
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "RAM message with %s", "RAM string 5");
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "RAM message with %s", "RAM string 1");
+  rf24Logger.warn((const __FlashStringHelper*) vendorID, "RAM message with %s",
+                  "RAM string 2");
+  rf24Logger.info((const __FlashStringHelper*) vendorID, "RAM message with %s",
+                  "RAM string 3");
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "RAM message with %s", "RAM string 4");
 
-   Serial.println();
+  Serial.println();
 }
 
 void logRamMessageWithProgmemStringArgument()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "RAM message with %S", (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.warn((const __FlashStringHelper*) vendorID, "RAM message with %S",
-         (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.info((const __FlashStringHelper*) vendorID, "RAM message with %S",
-         (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "RAM message with %S", (const __FlashStringHelper*) globalProgmemText);
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "RAM message with %S", (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "RAM message with %S", (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.warn((const __FlashStringHelper*) vendorID, "RAM message with %S",
+                  (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.info((const __FlashStringHelper*) vendorID, "RAM message with %S",
+                  (const __FlashStringHelper*) globalProgmemText);
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "RAM message with %S", (const __FlashStringHelper*) globalProgmemText);
 
-   Serial.println();
+  Serial.println();
 }
 
 void logRamMessageWithFMacroStringArgument()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "RAM message with %S", F("F macro string 1"));
-   rf24Logger.warn((const __FlashStringHelper*) vendorID, "RAM message with %S",
-         F("F macro string 2"));
-   rf24Logger.info((const __FlashStringHelper*) vendorID, "RAM message with %S",
-         F("F macro string 3"));
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "RAM message with %S", F("F macro string 4"));
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "RAM message with %S", F("F macro string 5"));
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "RAM message with %S", F("F macro string 1"));
+  rf24Logger.warn((const __FlashStringHelper*) vendorID, "RAM message with %S",
+                  F("F macro string 2"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID, "RAM message with %S",
+                  F("F macro string 3"));
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "RAM message with %S", F("F macro string 4"));
 
-   Serial.println();
+  Serial.println();
 }
 
 void logProgmemMessageWithRamStringArgument()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemMessageWithRamString,
-         "RAM string 1");
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemMessageWithRamString,
-         "RAM string 2");
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemMessageWithRamString,
-         "RAM string 3");
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemMessageWithRamString,
-         "RAM string 4");
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         (const __FlashStringHelper*) globalProgmemMessageWithRamString,
-         "RAM string 5");
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   (const __FlashStringHelper*) globalProgmemMessageWithRamString,
+                   "RAM string 1");
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  (const __FlashStringHelper*) globalProgmemMessageWithRamString,
+                  "RAM string 2");
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  (const __FlashStringHelper*) globalProgmemMessageWithRamString,
+                  "RAM string 3");
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   (const __FlashStringHelper*) globalProgmemMessageWithRamString,
+                   "RAM string 4");
 
-   Serial.println();
+  Serial.println();
 }
 
 void logMessageWithAdditionalTagAtTheBeginning()
 {
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         "%S info log with additional tag at the beginning", F("RF24Log.cpp"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  "%S info log with additional tag at the beginning", F("RF24Log.cpp"));
 
-   Serial.println();
+  Serial.println();
 }
 
 void logMessageWithUnknownFormat()
 {
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         "info log with unknown format   : %p", F("flash text"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  "info log with unknown format   : %p", F("flash text"));
 
-   Serial.println();
+  Serial.println();
 }
 
 void logFloatNumber()
 {
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         " info log with double value %D", 3.14);
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  " info log with double value %D", 3.14);
 
-   Serial.println();
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  " warn log with double value %D", 3.14);
 
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         " warn log with double value %D", 3.14);
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "error log with double value %D", 3.14);
 
-   Serial.println();
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "debug log with double value %F", 2.71);
 
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "error log with double value %D", 3.14);
-
-   Serial.println();
-
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "debug log with double value %F", 2.71);
-
-   Serial.println();
-
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "trace log with double value %F", 2.71);
-
-   Serial.println();
+  Serial.println();
 }
 
 void logCustomLogLevels()
 {
-   rf24Logger.log(RF24LogLevel::INFO + 1, (const __FlashStringHelper*) vendorID,
-            "INFO + 1 message defined in RAM");
+  rf24Logger.log(RF24LogLevel::INFO + 1, (const __FlashStringHelper*) vendorID,
+                 "INFO + 1 message defined in RAM");
 
-   rf24Logger.log(RF24LogLevel::WARN + 1, (const __FlashStringHelper*) vendorID,
-               F("WARN + 1 message defined in FLASH"));
+  rf24Logger.log(RF24LogLevel::WARN + 1, (const __FlashStringHelper*) vendorID,
+                 F("WARN + 1 message defined in FLASH"));
+
+  Serial.println();
 }

--- a/examples/DualLogger/DualLogger.ino
+++ b/examples/DualLogger/DualLogger.ino
@@ -30,14 +30,12 @@ RF24StreamLogHandler rf24SerialLogHandler2(&Serial);
 RF24DualLogHandler rf24DualLogHandler(&rf24SerialLogHandler1, &rf24SerialLogHandler2);
 
 // Define global vendor id (it is stored in flash memory)
-const char vendorID[] PROGMEM = "RF24LogExample";
+const char PROGMEM vendorID[] = "RF24LogExample";
 
 
 // Define some test messages stored in EEPROM
-const char globalProgmemText[] PROGMEM
-  = "global PROGMEM message";
-const char globalProgmemMessageWithRamString[] PROGMEM
-  = "PROGMEM message with %s";
+const char PROGMEM globalProgmemText[] = "global PROGMEM message";
+const char PROGMEM globalProgmemMessageWithRamString[] = "PROGMEM message with %s";
 
 void setup()
 {

--- a/examples/DualLogger/DualLogger.ino
+++ b/examples/DualLogger/DualLogger.ino
@@ -35,32 +35,32 @@ const char vendorID[] PROGMEM = "RF24LogExample";
 
 // Define some test messages stored in EEPROM
 const char globalProgmemText[] PROGMEM
-= "global PROGMEM message";
+  = "global PROGMEM message";
 const char globalProgmemMessageWithRamString[] PROGMEM
-= "PROGMEM message with %s";
+  = "PROGMEM message with %s";
 
 void setup()
 {
-   // configure serial port baudrate
-   Serial.begin(115200);
+  // configure serial port baudrate
+  Serial.begin(115200);
 
-   // set maximal log level to ALL
-   rf24DualLogHandler.setLogLevel(RF24LogLevel::ALL);
-   // set serial port appender
-   rf24Logger.setHandler(&rf24DualLogHandler);
+  // set maximal log level to ALL
+  rf24DualLogHandler.setLogLevel(RF24LogLevel::ALL);
+  // set serial port appender
+  rf24Logger.setHandler(&rf24DualLogHandler);
 
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/DualLogger"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/DualLogger"));
 }
 
 void loop()
 {
-   rf24DualLogHandler.setLogLevel(RF24LogLevel::ALL);
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("This message should be logged %s."), "twice");
+  rf24DualLogHandler.setLogLevel(RF24LogLevel::ALL);
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("This message should be logged %s."), "twice");
 
-   rf24DualLogHandler.setLogLevel(RF24LogLevel::INFO);
-   rf24Logger.warn((const __FlashStringHelper*) vendorID, F("This warn message should be logged %s."), "twice");
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("This info message should be logged %s."), "twice");
-   rf24Logger.debug((const __FlashStringHelper*) vendorID, F("This debug message should NOT be logged %s."));
+  rf24DualLogHandler.setLogLevel(RF24LogLevel::INFO);
+  rf24Logger.warn((const __FlashStringHelper*) vendorID, F("This warn message should be logged %s."), "twice");
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("This info message should be logged %s."), "twice");
+  rf24Logger.debug((const __FlashStringHelper*) vendorID, F("This debug message should NOT be logged %s."));
 
-   delay(5000);
+  delay(5000);
 }

--- a/examples/EmptyLogger/EmptyLogger.ino
+++ b/examples/EmptyLogger/EmptyLogger.ino
@@ -21,7 +21,7 @@
 #include <handlers/RF24StreamLogHandler.h>
 
 // Define global vendor id (it is stored in flash memory)
-const char vendorID[] PROGMEM = "RF24LogExample";
+const char PROGMEM vendorID[] = "RF24LogExample";
 
 // DO NOT create hardware serial port log appender
 // RF24StreamLogHandler rf24SerialLogHandler(&Serial);

--- a/examples/EmptyLogger/EmptyLogger.ino
+++ b/examples/EmptyLogger/EmptyLogger.ino
@@ -28,37 +28,35 @@ const char vendorID[] PROGMEM = "RF24LogExample";
 
 void setup()
 {
-   // configure serial port baudrate
-   Serial.begin(115200);
-   // DO NOT set serial port appender
-   // rf24Logger.setAppender(&rf24SerialLogAppender);
+  // configure serial port baudrate
+  Serial.begin(115200);
+  // DO NOT set serial port appender
+  // rf24Logger.setAppender(&rf24SerialLogAppender);
 
-   Serial.println("There is no appender defined. Nothing should be logged.");
+  Serial.println("There is no appender defined. Nothing should be logged.");
 
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/EmptyLogger"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/EmptyLogger"));
 }
 
 void logSimpleRamMessage();
 
 void loop()
 {
-   logSimpleRamMessage();
+  logSimpleRamMessage();
 
-   delay(5000);
+  delay(5000);
 }
 
 void logSimpleRamMessage()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "Error message defined in RAM");
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         "Warning message defined in RAM");
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         "Info message defined in RAM");
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "Debug message defined in RAM");
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "Trace message defined in RAM");
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "Error message defined in RAM");
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  "Warning message defined in RAM");
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  "Info message defined in RAM");
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "Debug message defined in RAM");
 
-   Serial.println();
+  Serial.println();
 }

--- a/examples/LogLevelsLogger/LogLevelsLogger.ino
+++ b/examples/LogLevelsLogger/LogLevelsLogger.ino
@@ -24,7 +24,7 @@
 RF24StreamLogHandler rf24SerialLogHandler(&Serial);
 
 // Define global vendor id (it is stored in flash memory)
-const char vendorID[] PROGMEM = "RF24LogExample";
+const char PROGMEM vendorID[] = "RF24LogExample";
 
 
 void logSimpleRamMessage();

--- a/examples/LogLevelsLogger/LogLevelsLogger.ino
+++ b/examples/LogLevelsLogger/LogLevelsLogger.ino
@@ -31,99 +31,92 @@ void logSimpleRamMessage();
 
 void setup()
 {
-   // configure serial port baudrate
-   Serial.begin(115200);
+  // configure serial port baudrate
+  Serial.begin(115200);
 
-   // set maximal log level to ALL
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
-   // set serial port appender
-   rf24Logger.setHandler(&rf24SerialLogHandler);
+  // set maximal log level to ALL
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
+  // set serial port appender
+  rf24Logger.setHandler(&rf24SerialLogHandler);
 
-   rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/LogLevelsLogger"));
+  rf24Logger.info((const __FlashStringHelper*) vendorID, F("RF24Log/examples/LogLevelsLogger"));
 }
 
 void loop()
 {
-   Serial.println("Set log level to OFF");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::OFF);
-   logSimpleRamMessage();
+  Serial.println("Set log level to OFF");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::OFF);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to ERROR");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ERROR);
-   logSimpleRamMessage();
+  Serial.println("Set log level to ERROR");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ERROR);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to ERROR + 1");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ERROR + 1);
-   logSimpleRamMessage();
+  Serial.println("Set log level to ERROR + 1");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ERROR + 1);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to ERROR + 7");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ERROR + 7);
-   logSimpleRamMessage();
+  Serial.println("Set log level to ERROR + 7");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ERROR + 7);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to WARN");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::WARN);
-   logSimpleRamMessage();
+  Serial.println("Set log level to WARN");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::WARN);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to INFO");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::INFO);
-   logSimpleRamMessage();
+  Serial.println("Set log level to INFO");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::INFO);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to DEBUG");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::DEBUG);
-   logSimpleRamMessage();
+  Serial.println("Set log level to DEBUG");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::DEBUG);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to DEBUG + 1");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::DEBUG + 1);
-   logSimpleRamMessage();
+  Serial.println("Set log level to DEBUG + 1");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::DEBUG + 1);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to DEBUG + 7");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::DEBUG + 7);
-   logSimpleRamMessage();
+  Serial.println("Set log level to DEBUG + 7");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::DEBUG + 7);
+  logSimpleRamMessage();
 
-   Serial.println("Set log level to ALL");
-   rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
-   logSimpleRamMessage();
+  Serial.println("Set log level to ALL");
+  rf24SerialLogHandler.setLogLevel(RF24LogLevel::ALL);
+  logSimpleRamMessage();
 
-   Serial.println("");
-   delay(5000);
+  Serial.println("");
+  delay(5000);
 }
 
 void logSimpleRamMessage()
 {
-   rf24Logger.error((const __FlashStringHelper*) vendorID,
-         "Error message");
-   rf24Logger.log(RF24LogLevel::ERROR + 1, (const __FlashStringHelper*) vendorID,
-            "Error message sub-level 1");
-   rf24Logger.log(RF24LogLevel::ERROR + 7, (const __FlashStringHelper*) vendorID,
-               "Error message sub-level 7");
+  rf24Logger.error((const __FlashStringHelper*) vendorID,
+                   "Error message");
+  rf24Logger.log(RF24LogLevel::ERROR + 1, (const __FlashStringHelper*) vendorID,
+                 "Error message sub-level 1");
+  rf24Logger.log(RF24LogLevel::ERROR + 7, (const __FlashStringHelper*) vendorID,
+                 "Error message sub-level 7");
 
-   rf24Logger.warn((const __FlashStringHelper*) vendorID,
-         "Warning message");
-   rf24Logger.log(RF24LogLevel::WARN + 1, (const __FlashStringHelper*) vendorID,
-               "Warning message sub-level 1");
-   rf24Logger.log(RF24LogLevel::WARN + 7, (const __FlashStringHelper*) vendorID,
-                  "Warning message sub-level 7");
+  rf24Logger.warn((const __FlashStringHelper*) vendorID,
+                  "Warning message");
+  rf24Logger.log(RF24LogLevel::WARN + 1, (const __FlashStringHelper*) vendorID,
+                 "Warning message sub-level 1");
+  rf24Logger.log(RF24LogLevel::WARN + 7, (const __FlashStringHelper*) vendorID,
+                 "Warning message sub-level 7");
 
-   rf24Logger.info((const __FlashStringHelper*) vendorID,
-         "Info message");
-   rf24Logger.log(RF24LogLevel::INFO + 1, (const __FlashStringHelper*) vendorID,
-               "Info message sub-level 1");
-   rf24Logger.log(RF24LogLevel::INFO + 7, (const __FlashStringHelper*) vendorID,
-                  "Info message sub-level 7");
+  rf24Logger.info((const __FlashStringHelper*) vendorID,
+                  "Info message");
+  rf24Logger.log(RF24LogLevel::INFO + 1, (const __FlashStringHelper*) vendorID,
+                 "Info message sub-level 1");
+  rf24Logger.log(RF24LogLevel::INFO + 7, (const __FlashStringHelper*) vendorID,
+                 "Info message sub-level 7");
 
-   rf24Logger.debug((const __FlashStringHelper*) vendorID,
-         "Debug message");
-   rf24Logger.log(RF24LogLevel::DEBUG + 1, (const __FlashStringHelper*) vendorID,
-                  "Debug message sub-level 1");
-   rf24Logger.log(RF24LogLevel::DEBUG + 7, (const __FlashStringHelper*) vendorID,
-                     "Debug message sub-level 7");
+  rf24Logger.debug((const __FlashStringHelper*) vendorID,
+                   "Debug message");
+  rf24Logger.log(RF24LogLevel::DEBUG + 1, (const __FlashStringHelper*) vendorID,
+                 "Debug message sub-level 1");
+  rf24Logger.log(RF24LogLevel::DEBUG + 7, (const __FlashStringHelper*) vendorID,
+                 "Debug message sub-level 7");
 
-   rf24Logger.trace((const __FlashStringHelper*) vendorID,
-         "Trace message");
-   rf24Logger.log(RF24LogLevel::TRACE + 1, (const __FlashStringHelper*) vendorID,
-                     "Trace message sub-level 1");
-   rf24Logger.log(RF24LogLevel::TRACE + 7, (const __FlashStringHelper*) vendorID,
-                        "Trace message sub-level 7");
-
-   Serial.println();
+  Serial.println();
 }

--- a/examples/examples_formatter.conf
+++ b/examples/examples_formatter.conf
@@ -1,0 +1,31 @@
+# This configuration file contains a selection of the available options provided by the formatting tool "Artistic Style"
+# http://astyle.sourceforge.net/astyle.html
+#
+# If you wish to change them, don't edit this file.
+# Instead, copy it in the same folder of file "preferences.txt" and modify the copy. This way, you won't lose your custom formatter settings when upgrading the IDE
+# If you don't know where file preferences.txt is stored, open the IDE, File -> Preferences and you'll find a link
+
+mode=c
+
+# 2 spaces indentation
+indent=spaces=2
+
+# also indent macros
+indent-preprocessor
+
+# indent classes, switches (and cases), comments starting at column 1
+indent-classes
+indent-switches
+indent-cases
+indent-col1-comments
+
+# put a space around operators
+pad-oper
+
+# put a space after if/for/while
+pad-header
+
+# if you like one-liners, keep them
+keep-one-line-statements
+
+# remove-comment-prefix

--- a/src/RF24LogHandler.h
+++ b/src/RF24LogHandler.h
@@ -5,8 +5,8 @@
  *     Author: Witold Markowski (wmarkow)
  *
  * Copyright (C)
- *    2020        Witold Markowski (wmarkow)
- *    2021        Brendan Doherty (2bndy5)
+ *      2020        Witold Markowski (wmarkow)
+ *      2021        Brendan Doherty (2bndy5)
  *
  * This General Public License does not permit incorporating your program into
  * proprietary programs.  If your program is a subroutine library, you may
@@ -29,27 +29,27 @@
 class RF24LogHandler
 {
 public:
-      /**
-       * log message.
-       * @param logLevel the level of the logging message
-       * @param vendorId The prefixed origin of the message
-       * @param message The message
-       */
-      virtual void log(uint8_t logLevel,
-                          const __FlashStringHelper *vendorId,
-                          const char *message,
-                          va_list *args);
+    /**
+     * @brief log a message.
+     * @param logLevel the level of the logging message
+     * @param vendorId The prefixed origin of the message
+     * @param message The message
+     */
+    virtual void log(uint8_t logLevel,
+                     const __FlashStringHelper *vendorId,
+                     const char *message,
+                     va_list *args);
 
-      /**
-       * log message.
-       * @param logLevel the level of the logging message
-       * @param vendorId The prefixed origin of the message
-       * @param message The message
-       */
-      virtual void log(uint8_t logLevel,
-                          const __FlashStringHelper *vendorId,
-                          const __FlashStringHelper *message,
-                          va_list *args);
+    /**
+     * @brief log a message.
+     * @param logLevel the level of the logging message
+     * @param vendorId The prefixed origin of the message
+     * @param message The message
+     */
+    virtual void log(uint8_t logLevel,
+                     const __FlashStringHelper *vendorId,
+                     const __FlashStringHelper *message,
+                     va_list *args);
 
       /**
        * set the maximal level of the logged messages.

--- a/src/RF24LogLevel.h
+++ b/src/RF24LogLevel.h
@@ -5,8 +5,8 @@
  *     Author: Witold Markowski (wmarkow)
  *
  * Copyright (C)
- *    2020        Witold Markowski (wmarkow)
- *    2021        Brendan Doherty (2bndy5)
+ *      2020        Witold Markowski (wmarkow)
+ *      2021        Brendan Doherty (2bndy5)
  *
  * This General Public License does not permit incorporating your program into
  * proprietary programs.  If your program is a subroutine library, you may
@@ -23,20 +23,18 @@
 /** the predefined logging levels */
 enum RF24LogLevel : uint8_t
 {
-   /** the level to disable all log messages */
-     OFF = 0x00,
-   /** the level to specify an error message */
-   ERROR = 0x08,
-   /** the level to specify an warning message */
+    /** the level to disable all log messages */
+    OFF = 0x00,
+    /** the level to specify an error message */
+    ERROR = 0x08,
+    /** the level to specify an warning message */
     WARN = 0x10,
-   /** the level to specify an informational message */
+    /** the level to specify an informational message */
     INFO = 0x18,
-   /** the level to specify an debugging message */
-   DEBUG = 0x20,
-   /** the level to specify an traceback message */
-   TRACE = 0x28,
-   /** the level to enable all log messages */
-     ALL = 0xFF
+    /** the level to specify an debugging message */
+    DEBUG = 0x20,
+    /** the level to enable all log messages (disables filtering of levels) */
+    ALL = 0xFF
 };
 
 #endif /* SRC_RF24LOGLEVEL_H_ */

--- a/src/RF24Logger.cpp
+++ b/src/RF24Logger.cpp
@@ -18,12 +18,12 @@
 
 RF24Logger::RF24Logger()
 {
-   this->handler = nullptr;
+    this->handler = nullptr;
 }
 
 void RF24Logger::setHandler(RF24LogHandler *handler)
 {
-   this->handler = handler;
+    this->handler = handler;
 }
 
 // default logger instance

--- a/src/RF24Logger.h
+++ b/src/RF24Logger.h
@@ -31,23 +31,21 @@ private:
     RF24LogHandler *handler;
 
 public:
-    /**
-    * @brief Initializes the appender to nullptr
-    */
+    /** @brief Initializes the appender to nullptr */
     RF24Logger();
 
     /**
-    * @brief set the instance's handler
-    * @param handler The log handler where the messages will be redirected.
-    */
+     * @brief set the instance's handler
+     * @param handler The log handler where the messages will be redirected.
+     */
     void setHandler(RF24LogHandler *handler);
 
     /**
-    * @brief ouput an ERROR message
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
+     * @brief ouput an ERROR message
+     * @param vendorId A scoping identity of the message's origin
+     * @param message The message to output
+     * @param args consumable arguments
+     */
     template <class T>
     void error(const __FlashStringHelper *vendorId, T message, ...)
     {
@@ -61,11 +59,11 @@ public:
     }
 
     /**
-    * @brief output a message to WARN the reader
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
+     * @brief output a message to WARN the reader
+     * @param vendorId A scoping identity of the message's origin
+     * @param message The message to output
+     * @param args consumable arguments
+     */
     template <class T>
     void warn(const __FlashStringHelper *vendorId, T message, ...)
     {
@@ -79,11 +77,11 @@ public:
     }
 
     /**
-    * @brief output an INFO message
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
+     * @brief output an INFO message
+     * @param vendorId A scoping identity of the message's origin
+     * @param message The message to output
+     * @param args consumable arguments
+     */
     template <class T>
     void info(const __FlashStringHelper *vendorId, T message, ...)
     {
@@ -97,11 +95,11 @@ public:
     }
 
     /**
-    * @brief output a message to help developers DEBUG their source code
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
+     * @brief output a message to help developers DEBUG their source code
+     * @param vendorId A scoping identity of the message's origin
+     * @param message The message to output
+     * @param args consumable arguments
+     */
     template <class T>
     void debug(const __FlashStringHelper *vendorId, T message, ...)
     {
@@ -115,11 +113,11 @@ public:
     }
 
     /**
-    * @brief output a log message of any level
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
+     * @brief output a log message of any level
+     * @param vendorId A scoping identity of the message's origin
+     * @param message The message to output
+     * @param args consumable arguments
+     */
     template <class T>
     void log(uint8_t logLevel, const __FlashStringHelper *vendorId, T message, ...)
     {

--- a/src/RF24Logger.h
+++ b/src/RF24Logger.h
@@ -28,122 +28,109 @@
 class RF24Logger
 {
 private:
-   RF24LogHandler *handler;
+    RF24LogHandler *handler;
 
 public:
-
-   /**
-    * Initializes the appender to nullptr
+    /**
+    * @brief Initializes the appender to nullptr
     */
-   RF24Logger();
+    RF24Logger();
 
-   /**
-    * set the instance's handler
+    /**
+    * @brief set the instance's handler
     * @param handler The log handler where the messages will be redirected.
     */
-   void setHandler(RF24LogHandler *handler);
+    void setHandler(RF24LogHandler *handler);
 
-   /**
-    * ouput an ERROR message
+    /**
+    * @brief ouput an ERROR message
     * @param vendorId A scoping identity of the message's origin
     * @param message The message to output
     * @param args consumable arguments
     */
-   template<class T> void error(
-         const __FlashStringHelper *vendorId, T message, ...)
-   {
-      if (handler == nullptr)
-      {
-         return;
-      }
-      va_list args;
-      va_start(args, message);
-      handler->log(RF24LogLevel::ERROR, vendorId, message, &args);
-   }
-
-   /**
-    * output a message to WARN the reader
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
-   template<class T> void warn(
-         const __FlashStringHelper *vendorId, T message, ...)
-   {
-      if (handler == nullptr)
-      {
-         return;
-      }
-      va_list args;
-      va_start(args, message);
-      handler->log(RF24LogLevel::WARN, vendorId, message, &args);
-   }
-
-   /**
-    * output an INFO message
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
-   template<class T> void info(
-         const __FlashStringHelper *vendorId, T message, ...)
-   {
-      if (handler == nullptr)
-      {
-         return;
-      }
-      va_list args;
-      va_start(args, message);
-      handler->log(RF24LogLevel::INFO, vendorId, message, &args);
-   }
-
-   /**
-    * output a message to help developers DEBUG their source code
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
-   template<class T> void debug(
-         const __FlashStringHelper *vendorId, T message, ...)
-   {
-      if (handler == nullptr)
-      {
-         return;
-      }
-      va_list args;
-      va_start(args, message);
-      handler->log(RF24LogLevel::DEBUG, vendorId, message, &args);
-   }
-
-   /**
-    * output a TRACE message that points to an event's instigator
-    * @param vendorId A scoping identity of the message's origin
-    * @param message The message to output
-    * @param args consumable arguments
-    */
-   template<class T> void trace(
-         const __FlashStringHelper *vendorId, T message, ...)
-   {
-      if (handler == nullptr)
-      {
-         return;
-      }
-      va_list args;
-      va_start(args, message);
-      handler->log(RF24LogLevel::TRACE, vendorId, message, &args);
-   }
-
-   template<class T> void log(
-            uint8_t logLevel, const __FlashStringHelper *vendorId, T message, ...)
-      {
-         if (handler == nullptr)
-         {
+    template <class T>
+    void error(const __FlashStringHelper *vendorId, T message, ...)
+    {
+        if (handler == nullptr)
+        {
             return;
-         }
-         va_list args;
-         va_start(args, message);
-         handler->log(logLevel, vendorId, message, &args);
-      }
+        }
+        va_list args;
+        va_start(args, message);
+        handler->log(RF24LogLevel::ERROR, vendorId, message, &args);
+    }
+
+    /**
+    * @brief output a message to WARN the reader
+    * @param vendorId A scoping identity of the message's origin
+    * @param message The message to output
+    * @param args consumable arguments
+    */
+    template <class T>
+    void warn(const __FlashStringHelper *vendorId, T message, ...)
+    {
+        if (handler == nullptr)
+        {
+            return;
+        }
+        va_list args;
+        va_start(args, message);
+        handler->log(RF24LogLevel::WARN, vendorId, message, &args);
+    }
+
+    /**
+    * @brief output an INFO message
+    * @param vendorId A scoping identity of the message's origin
+    * @param message The message to output
+    * @param args consumable arguments
+    */
+    template <class T>
+    void info(const __FlashStringHelper *vendorId, T message, ...)
+    {
+        if (handler == nullptr)
+        {
+            return;
+        }
+        va_list args;
+        va_start(args, message);
+        handler->log(RF24LogLevel::INFO, vendorId, message, &args);
+    }
+
+    /**
+    * @brief output a message to help developers DEBUG their source code
+    * @param vendorId A scoping identity of the message's origin
+    * @param message The message to output
+    * @param args consumable arguments
+    */
+    template <class T>
+    void debug(const __FlashStringHelper *vendorId, T message, ...)
+    {
+        if (handler == nullptr)
+        {
+            return;
+        }
+        va_list args;
+        va_start(args, message);
+        handler->log(RF24LogLevel::DEBUG, vendorId, message, &args);
+    }
+
+    /**
+    * @brief output a log message of any level
+    * @param vendorId A scoping identity of the message's origin
+    * @param message The message to output
+    * @param args consumable arguments
+    */
+    template <class T>
+    void log(uint8_t logLevel, const __FlashStringHelper *vendorId, T message, ...)
+    {
+        if (handler == nullptr)
+        {
+            return;
+        }
+        va_list args;
+        va_start(args, message);
+        handler->log(logLevel, vendorId, message, &args);
+    }
 };
 
 /**

--- a/src/handlers/RF24AbstractLogHandler.cpp
+++ b/src/handlers/RF24AbstractLogHandler.cpp
@@ -18,36 +18,36 @@
 
 RF24AbstractLogHandler::RF24AbstractLogHandler()
 {
-   this->logLevel = RF24LogLevel::INFO;
+    this->logLevel = RF24LogLevel::INFO;
 }
 
 void RF24AbstractLogHandler::setLogLevel(uint8_t logLevel)
 {
-   this->logLevel = logLevel;
+    this->logLevel = logLevel;
 }
 
-void RF24AbstractLogHandler::log(uint8_t logLevel,
-              const __FlashStringHelper *vendorId,
-              const char *message,
-              va_list *args)
+void RF24LogHandler::log(uint8_t logLevel,
+                         const __FlashStringHelper *vendorId,
+                         const char *message,
+                         va_list *args)
 {
-   if(logLevel > this->logLevel)
-   {
-      return;
-   }
+    if (logLevel > this->logLevel)
+    {
+        return;
+    }
 
-   write(logLevel, vendorId, message, args);
+    write(logLevel, vendorId, message, args);
 }
 
-void RF24AbstractLogHandler::log(uint8_t logLevel,
-              const __FlashStringHelper *vendorId,
-              const __FlashStringHelper *message,
-              va_list *args)
+void RF24LogHandler::log(uint8_t logLevel,
+                         const __FlashStringHelper *vendorId,
+                         const __FlashStringHelper *message,
+                         va_list *args)
 {
-   if(logLevel > this->logLevel)
-   {
-      return;
-   }
+    if (logLevel > this->logLevel)
+    {
+        return;
+    }
 
-   write(logLevel, vendorId, message, args);
+    write(logLevel, vendorId, message, args);
 }

--- a/src/handlers/RF24AbstractLogHandler.cpp
+++ b/src/handlers/RF24AbstractLogHandler.cpp
@@ -26,10 +26,10 @@ void RF24AbstractLogHandler::setLogLevel(uint8_t logLevel)
     this->logLevel = logLevel;
 }
 
-void RF24LogHandler::log(uint8_t logLevel,
-                         const __FlashStringHelper *vendorId,
-                         const char *message,
-                         va_list *args)
+void RF24AbstractLogHandler::log(uint8_t logLevel,
+                                 const __FlashStringHelper *vendorId,
+                                 const char *message,
+                                 va_list *args)
 {
     if (logLevel > this->logLevel)
     {
@@ -39,10 +39,10 @@ void RF24LogHandler::log(uint8_t logLevel,
     write(logLevel, vendorId, message, args);
 }
 
-void RF24LogHandler::log(uint8_t logLevel,
-                         const __FlashStringHelper *vendorId,
-                         const __FlashStringHelper *message,
-                         va_list *args)
+void RF24AbstractLogHandler::log(uint8_t logLevel,
+                                 const __FlashStringHelper *vendorId,
+                                 const __FlashStringHelper *message,
+                                 va_list *args)
 {
     if (logLevel > this->logLevel)
     {

--- a/src/handlers/RF24AbstractLogHandler.h
+++ b/src/handlers/RF24AbstractLogHandler.h
@@ -38,9 +38,9 @@ public:
        * @param message The message
        */
       void log(uint8_t logLevel,
-                          const __FlashStringHelper *vendorId,
-                          const char *message,
-                          va_list *args);
+               const __FlashStringHelper *vendorId,
+               const char *message,
+               va_list *args);
 
       /**
        * log message.
@@ -49,9 +49,9 @@ public:
        * @param message The message
        */
       void log(uint8_t logLevel,
-                          const __FlashStringHelper *vendorId,
-                          const __FlashStringHelper *message,
-                          va_list *args);
+               const __FlashStringHelper *vendorId,
+               const __FlashStringHelper *message,
+               va_list *args);
 
       /**
        * set the maximal level of the logged messages.

--- a/src/handlers/RF24DualLogHandler.cpp
+++ b/src/handlers/RF24DualLogHandler.cpp
@@ -17,41 +17,44 @@
 #include <handlers/RF24DualLogHandler.h>
 
 RF24DualLogHandler::RF24DualLogHandler(RF24LogHandler *handler1,
-      RF24LogHandler *handler2)
+                                       RF24LogHandler *handler2)
 {
-   this->handler1 = handler1;
-   this->handler2 = handler2;
+    this->handler1 = handler1;
+    this->handler2 = handler2;
 }
 
 void RF24DualLogHandler::log(uint8_t logLevel,
-      const __FlashStringHelper *vendorId, const char *message, va_list *args)
+                             const __FlashStringHelper *vendorId,
+                             const char *message,
+                             va_list *args)
 {
-   // va_list can be iterated only once.
-   // Since we have here two handlers, we need to copy arguments.
-   va_list args2;
-   va_copy(args2, *args);
+    // va_list can be iterated only once.
+    // Since we have here two handlers, we need to copy arguments.
+    va_list args2;
+    va_copy(args2, *args);
 
-   // redirect logs to wrapped handlers
-   handler1->log(logLevel, vendorId, message, args);
-   handler2->log(logLevel, vendorId, message, &args2);
+    // redirect logs to wrapped handlers
+    handler1->log(logLevel, vendorId, message, args);
+    handler2->log(logLevel, vendorId, message, &args2);
 }
 
 void RF24DualLogHandler::log(uint8_t logLevel,
-      const __FlashStringHelper *vendorId, const __FlashStringHelper *message,
-      va_list *args)
+                             const __FlashStringHelper *vendorId,
+                             const __FlashStringHelper *message,
+                             va_list *args)
 {
-   // va_list can be iterated only once.
-   // Since we have here two handlers, we need to copy arguments.
-   va_list args2;
-   va_copy(args2, *args);
+    // va_list can be iterated only once.
+    // Since we have here two handlers, we need to copy arguments.
+    va_list args2;
+    va_copy(args2, *args);
 
-   // redirect logs to wrapped handlers
-   handler1->log(logLevel, vendorId, message, args);
-   handler2->log(logLevel, vendorId, message, &args2);
+    // redirect logs to wrapped handlers
+    handler1->log(logLevel, vendorId, message, args);
+    handler2->log(logLevel, vendorId, message, &args2);
 }
 
 void RF24DualLogHandler::setLogLevel(uint8_t logLevel)
 {
-   handler1->setLogLevel(logLevel);
-   handler2->setLogLevel(logLevel);
+    handler1->setLogLevel(logLevel);
+    handler2->setLogLevel(logLevel);
 }

--- a/src/handlers/RF24DualLogHandler.h
+++ b/src/handlers/RF24DualLogHandler.h
@@ -25,25 +25,23 @@
 class RF24DualLogHandler : public RF24LogHandler
 {
 private:
-   RF24LogHandler *handler1;
-   RF24LogHandler *handler2;
+    RF24LogHandler *handler1;
+    RF24LogHandler *handler2;
 
 public:
-   RF24DualLogHandler(RF24LogHandler *handler1, RF24LogHandler *handler2);
+    RF24DualLogHandler(RF24LogHandler *handler1, RF24LogHandler *handler2);
 
-   void log(uint8_t logLevel,
-                       const __FlashStringHelper *vendorId,
-                       const char *message,
-                       va_list *args);
+    void log(uint8_t logLevel,
+             const __FlashStringHelper *vendorId,
+             const char *message,
+             va_list *args);
 
-   void log(uint8_t logLevel,
-                       const __FlashStringHelper *vendorId,
-                       const __FlashStringHelper *message,
-                       va_list *args);
+    void log(uint8_t logLevel,
+             const __FlashStringHelper *vendorId,
+             const __FlashStringHelper *message,
+             va_list *args);
 
    void setLogLevel(uint8_t logLevel);
 };
-
-
 
 #endif /* SRC_HANDLERS_RF24DUALLOGHANDLER_H_ */

--- a/src/handlers/RF24StreamLogHandler.cpp
+++ b/src/handlers/RF24StreamLogHandler.cpp
@@ -5,7 +5,8 @@
  *     Author: Witold Markowski (wmarkow)
  *
  * Copyright (C)
- *    2020        Witold Markowski (wmarkow)
+ *      2020        Witold Markowski (wmarkow)
+ *      2021        Brendan Doherty (2bndy5)
  *
  * This General Public License does not permit incorporating your program into
  * proprietary programs.  If your program is a subroutine library, you may
@@ -21,192 +22,188 @@ const char rf24logLevelError[] = "ERROR";
 const char rf24logLevelWarn[] = " WARN";
 const char rf24logLevelInfo[] = " INFO";
 const char rf24logLevelDebug[] = "DEBUG";
-const char rf24logLevelTrace[] = "TRACE";
 
 const char *const rf24LogLevels[] = {rf24logLevelError,
                                      rf24logLevelWarn,
                                      rf24logLevelInfo,
-                                     rf24logLevelDebug,
-                                     rf24logLevelTrace};
+                                     rf24logLevelDebug};
 
 RF24StreamLogHandler::RF24StreamLogHandler(Print *stream)
 {
-   this->stream = stream;
+    this->stream = stream;
 }
 
 void RF24StreamLogHandler::write(uint8_t logLevel,
-                                   const __FlashStringHelper *vendorId,
-                                   const char *message,
-                                   va_list *args)
+                                 const __FlashStringHelper *vendorId,
+                                 const char *message,
+                                 va_list *args)
 {
-   appendTimestamp();
-   appendLogLevel(logLevel);
-   appendVendorId(vendorId);
+    appendTimestamp();
+    appendLogLevel(logLevel);
+    appendVendorId(vendorId);
 
-   // print formatted message
-   appendFormattedMessage(message, args);
-   stream->println("");
+    // print formatted message
+    appendFormattedMessage(message, args);
+    stream->println("");
 }
 
 void RF24StreamLogHandler::write(uint8_t logLevel,
-                                   const __FlashStringHelper *vendorId,
-                                   const __FlashStringHelper *message,
-                                   va_list *args)
+                                 const __FlashStringHelper *vendorId,
+                                 const __FlashStringHelper *message,
+                                 va_list *args)
 {
-   appendTimestamp();
-   appendLogLevel(logLevel);
-   appendVendorId(vendorId);
+    appendTimestamp();
+    appendLogLevel(logLevel);
+    appendVendorId(vendorId);
 
-   // print formatted message
-   appendFormattedMessage(message, args);
-   stream->println("");
+    // print formatted message
+    appendFormattedMessage(message, args);
+    stream->println("");
 }
 
 void RF24StreamLogHandler::appendFormattedMessage(const char *format, va_list *args)
 {
-   for (; *format != 0; ++format)
-   {
-      if (*format == '%')
-      {
-         ++format;
-         appendFormat(*format, args);
-      }
-      else
-      {
-         stream->print(*format);
-      }
-   }
+    for (; *format != 0; ++format)
+    {
+        if (*format == '%')
+        {
+            ++format;
+            appendFormat(*format, args);
+        }
+        else
+        {
+            stream->print(*format);
+        }
+    }
 }
 
 void RF24StreamLogHandler::appendFormattedMessage(const __FlashStringHelper *format, va_list *args)
 {
-   PGM_P p = reinterpret_cast<PGM_P>(format);
-   char c = pgm_read_byte(p++);
-   for (; c != 0; c = pgm_read_byte(p++))
-   {
-      if (c == '%')
-      {
-         c = pgm_read_byte(p++);
-         appendFormat(c, args);
-      }
-      else
-      {
-         stream->print(c);
-      }
-   }
+    PGM_P p = reinterpret_cast<PGM_P>(format);
+    char c = pgm_read_byte(p++);
+    for (; c != 0; c = pgm_read_byte(p++))
+    {
+        if (c == '%')
+        {
+            c = pgm_read_byte(p++);
+            appendFormat(c, args);
+        }
+        else
+        {
+            stream->print(c);
+        }
+    }
 }
 
 void RF24StreamLogHandler::appendFormat(const char format, va_list *args)
 {
-   if (format == 's')
-   {
-      // print text from RAM
-      register char *s = (char *)va_arg(*args, int);
-      stream->print(s);
+    if (format == 's')
+    {
+        // print text from RAM
+        register char *s = (char *)va_arg(*args, int);
+        stream->print(s);
 
-      return;
-   }
+        return;
+    }
 
-   if (format == 'S')
-   {
-      // print text from FLASH
-      register __FlashStringHelper *s = (__FlashStringHelper *)va_arg(*args, int);
-      stream->print(s);
+    if (format == 'S')
+    {
+        // print text from FLASH
+        register __FlashStringHelper *s = (__FlashStringHelper *)va_arg(*args, int);
+        stream->print(s);
 
-      return;
-   }
+        return;
+    }
 
-   if (format == 'D' || format == 'F')
-   {
-      // print as double
-      stream->print(va_arg(*args, double));
+    if (format == 'D' || format == 'F')
+    {
+        // print as double
+        stream->print(va_arg(*args, double));
 
-      return;
-   }
+        return;
+    }
 
-   if (format == 'd' || format == 'i')
-   {
-      // print as integer
-      stream->print(va_arg(*args, int), DEC);
+    if (format == 'd' || format == 'i')
+    {
+        // print as integer
+        stream->print(va_arg(*args, int), DEC);
 
-      return;
-   }
+        return;
+    }
 
-   stream->print(format);
+    stream->print(format);
 }
 
 void RF24StreamLogHandler::appendTimestamp()
 {
-   char c[12];
-   sprintf(c, "%10lu ", millis());
-   stream->print(c);
-   stream->print(" ");
+    char c[12];
+    sprintf(c, "%10lu ", millis());
+    stream->print(c);
+    stream->print(" ");
 }
 
 void RF24StreamLogHandler::appendLogLevel(uint8_t logLevel)
 {
-   uint8_t logMainLevel = logLevel & 0xF8;
-   uint8_t subLevel = logLevel & 0x07;
+    uint8_t logMainLevel = logLevel & 0xF8;
+    uint8_t subLevel = logLevel & 0x07;
 
-   switch(logMainLevel)
-   {
-      case RF24LogLevel::ERROR:
-      {
-         stream->print(rf24LogLevels[0]);
-         break;
-      }
-      case RF24LogLevel::WARN:
-      {
-         stream->print(rf24LogLevels[1]);
-         break;
-      }
-      case RF24LogLevel::INFO:
-      {
-         stream->print(rf24LogLevels[2]);
-         break;
-      }
-      case RF24LogLevel::DEBUG:
-      {
-         stream->print(rf24LogLevels[3]);
-         break;
-      }
-      case RF24LogLevel::TRACE:
-      {
-         stream->print(rf24LogLevels[4]);
-         break;
-      }
-      default:
-      {
-         // unknown
-         if(logLevel < 10)
-         {
+    switch (logMainLevel)
+    {
+    case RF24LogLevel::ERROR:
+    {
+        stream->print(rf24LogLevels[0]);
+        break;
+    }
+    case RF24LogLevel::WARN:
+    {
+        stream->print(rf24LogLevels[1]);
+        break;
+    }
+    case RF24LogLevel::INFO:
+    {
+        stream->print(rf24LogLevels[2]);
+        break;
+    }
+    case RF24LogLevel::DEBUG:
+    {
+        stream->print(rf24LogLevels[3]);
+        break;
+    }
+    default:
+    {
+        // unknown
+        if (logLevel < 10)
+        {
             stream->print("Lvl   ");
-         } else if (logLevel < 100)
-         {
+        }
+        else if (logLevel < 100)
+        {
             stream->print("Lvl  ");
-         } else
-         {
+        }
+        else
+        {
             stream->print("Lvl ");
-         }
-         stream->print(logLevel);
-         stream->print(" ");
-         return;
-      }
-   }
+        }
+        stream->print(logLevel);
+        stream->print(" ");
+        return;
+    }
+    }
 
-   if(subLevel == 0)
-   {
-      stream->print("   ");
-   } else
-   {
-      stream->print(":");
-      stream->print(subLevel);
-      stream->print(" ");
-   }
+    if (subLevel == 0)
+    {
+        stream->print("   ");
+    }
+    else
+    {
+        stream->print(":");
+        stream->print(subLevel);
+        stream->print(" ");
+    }
 }
 
 void RF24StreamLogHandler::appendVendorId(const __FlashStringHelper *vendorId)
 {
-   stream->print(vendorId);
-   stream->print(" ");
+    stream->print(vendorId);
+    stream->print(" ");
 }

--- a/src/handlers/RF24StreamLogHandler.h
+++ b/src/handlers/RF24StreamLogHandler.h
@@ -26,24 +26,28 @@
 class RF24StreamLogHandler : public RF24AbstractLogHandler
 {
 protected:
-   Print *stream;
+    Print *stream;
 
 public:
-   RF24StreamLogHandler(Print *stream);
+    RF24StreamLogHandler(Print *stream);
 
 protected:
-   void write(uint8_t logLevel, const __FlashStringHelper *vendorId,
-         const char *message, va_list *args);
+    void write(uint8_t logLevel,
+               const __FlashStringHelper *vendorId,
+               const char *message,
+               va_list *args);
 
-   void write(uint8_t logLevel, const __FlashStringHelper *vendorId,
-         const __FlashStringHelper *message, va_list *args);
+    void write(uint8_t logLevel,
+               const __FlashStringHelper *vendorId,
+               const __FlashStringHelper *message,
+               va_list *args);
 
-   void appendTimestamp();
-   void appendLogLevel(uint8_t logLevel);
-   void appendVendorId(const __FlashStringHelper *vendorId);
-   void appendFormattedMessage(const char *format, va_list *args);
-   void appendFormattedMessage(const __FlashStringHelper *format, va_list *args);
-   void appendFormat(const char format, va_list *args);
+    void appendTimestamp();
+    void appendLogLevel(uint8_t logLevel);
+    void appendVendorId(const __FlashStringHelper *vendorId);
+    void appendFormattedMessage(const char *format, va_list *args);
+    void appendFormattedMessage(const __FlashStringHelper *format, va_list *args);
+    void appendFormat(const char format, va_list *args);
 };
 
 #endif /* SRC_HANDLERS_RF24STREAMLOGHANDLER_H_ */


### PR DESCRIPTION
Not going to repeat what the title says. But I do want to draw attention to the Arduino CI workflow. Turns out that the [`__FlashStringHelper` isn't compatible with all Arduino boards](https://github.com/2bndy5/RF24Log/runs/2261575950?check_suite_focus=true#step:3:18) (probably another _pgmspace.h_ problem).

If you question the formatting changes, please review the NASA C style guide in the CONTRIBUTING.md file. Arduino examples follow a slightly different format because the Arduino IDE uses a different set of rules in formatting code (ie the menu option to "format sketch")

tagging @avamander since this isn't an upstream PR

EDIT: Note [_WString.h_ includes _avr/pgmspace.h_](https://github.com/arduino/ArduinoCore-avr/blob/9f8d27f09f3bbd1da1374b5549a82bda55d45d44/cores/arduino/WString.h#L29), and _WString.h_ (like _pgmspace.h_) isn't available to all Arduino cores. [This is what _String.h_ does to compensate](https://github.com/arduino/ArduinoCore-API/blob/2af4a9c721f96b80010caf6923a12809f13026cd/api/String.h#L30-L45).